### PR TITLE
update readme for pages, alpha status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
+# Alpha Status
+
+This project is presently in alpha status and chart availabiliy in the helm repos below is limited and may be unstable.
+
 # F5 Networks Helm Charts
 
 To use the charts in this repository to deploy the [F5 k8s-bigip-ctlr](https://github.com/F5Networks/k8s-bigip-ctlr) using [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) or [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/):
 
 ```
-helm repo add f5-stable https://F5Networks.github.io/charts/stable
+helm repo add f5-stable https://f5networks.github.io/charts/stable
 helm install f5-stable/f5-bigip-ctlr
 ```
 
 To access additional charts in beta:
 
 ```
-helm repo add f5-incubator https://F5Networks.github.io/charts/incubator
+helm repo add f5-incubator https://f5networks.github.io/charts/incubator
 ```
 
 ## Repository Structure


### PR DESCRIPTION
Problem:
- Though the repo can remain private while the first chart is developed, some repo bootstrapping requires the server -- github pages -- to be active, and pages are public.
- url for pages is lowercase though GitHub organization and repos are CamelCase.

Solution:
- Added alpha notice
- fixed casing in helm repo listings