### PR TITLE
Fix #17: Make RBAC resources unique and optional

### DIFF
--- a/src/incubator/f5-bigip-ctlr/Chart.yaml
+++ b/src/incubator/f5-bigip-ctlr/Chart.yaml
@@ -1,4 +1,9 @@
 apiVersion: v1
 description: Deploy the F5 Networks BIG-IP Controller for Kubernetes and OpenShift (k8s-bigip-ctlr).
 name: f5-bigip-ctlr
-version: 0.0.4
+version: 0.1.0
+home: https://github.com/F5Networks/charts
+keywords:
+  - f5-bigip
+sources:
+  - https://clouddocs.f5.com/containers/v2/kubernetes/kctlr-k8s-ingress-ctlr.html

--- a/src/incubator/f5-bigip-ctlr/templates/_helpers.tpl
+++ b/src/incubator/f5-bigip-ctlr/templates/_helpers.tpl
@@ -9,8 +9,35 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "f5-bigip-ctlr.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "f5-bigip-ctlr.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cert-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cert-manager.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
 {{- end -}}

--- a/src/incubator/f5-bigip-ctlr/templates/f5-bigip-ctlr-clusterrole.yaml
+++ b/src/incubator/f5-bigip-ctlr/templates/f5-bigip-ctlr-clusterrole.yaml
@@ -1,10 +1,11 @@
+{{- if .Values.rbac.create -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: f5-bigip-ctlr-clusterrole
+  name: {{ template "f5-bigip-ctlr.fullname" . }}
   labels:
     app: {{ template "f5-bigip-ctlr.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "f5-bigip-ctlr.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
@@ -37,3 +38,4 @@ rules:
   - update
   - create
   - patch
+{{- end -}}

--- a/src/incubator/f5-bigip-ctlr/templates/f5-bigip-ctlr-clusterrolebinding.yaml
+++ b/src/incubator/f5-bigip-ctlr/templates/f5-bigip-ctlr-clusterrolebinding.yaml
@@ -1,11 +1,12 @@
+{{- if .Values.rbac.create -}}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: f5-bigip-ctlr-clusterrolebinding
-  namespace: kube-system
+  name: {{ template "f5-bigip-ctlr.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "f5-bigip-ctlr.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "f5-bigip-ctlr.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 roleRef:
@@ -14,5 +15,6 @@ roleRef:
   name: f5-bigip-ctlr-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: f5-bigip-ctlr-serviceaccount
-  namespace: kube-system
+  name: {{ template "f5-bigip-ctlr.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end -}}

--- a/src/incubator/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
+++ b/src/incubator/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
@@ -9,10 +9,10 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "f5-bigip-ctlr.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "f5-bigip-ctlr.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "-" }}
+    chart: {{ template "f5-bigip-ctlr.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -23,7 +23,7 @@ spec:
         app: {{ template "f5-bigip-ctlr.name" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ .Values.serviceaccount }}
+      serviceAccountName: {{ template "f5-bigip-ctlr.serviceAccountName" . }}
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range $pullSecret := .Values.image.pullSecrets }}

--- a/src/incubator/f5-bigip-ctlr/templates/f5-bigip-ctlr-serviceaccount.yaml
+++ b/src/incubator/f5-bigip-ctlr/templates/f5-bigip-ctlr-serviceaccount.yaml
@@ -1,10 +1,14 @@
+{{- if .Values.rbac.create -}}
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: f5-bigip-ctlr-serviceaccount
-  namespace: kube-system
+  name: {{ template "f5-bigip-ctlr.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "f5-bigip-ctlr.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "f5-bigip-ctlr.chart" . }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }} 
+    heritage: {{ .Release.Service }}
+{{- end -}}
+{{- end -}}

--- a/src/incubator/f5-bigip-ctlr/values.yaml
+++ b/src/incubator/f5-bigip-ctlr/values.yaml
@@ -6,9 +6,18 @@
 # To create a secret using kubectl see
 # http://clouddocs.f5.com/containers/latest/kubernetes/kctlr-secrets.html#secret-bigip-login
 bigip_login_secret: f5-bigip-ctlr-login
-serviceaccount: f5-bigip-ctlr-serviceaccount
-# This namespace is where the Controller lives;
-namespace: kube-system
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
 args:
   # See http://clouddocs.f5.com/products/connectors/k8s-bigip-ctlr/latest/#controller-configuration-parameters
   # NOTE: helm has difficulty with values using `-`; `_` are used for naming


### PR DESCRIPTION
Problem:
With the current Chart RBAC resource names are hard coded and not optional
so it's impossible to deploy more than one instance in a namespace

Solution:
This uses the helper f5-bigip-ctlr.fullname as the name of each resource to it's unique.
It also add variables to make the RBAc resources optional.
You can also set the name of the service account to use so you can use it across all deploys.

Testing (optional if not described in Solution section): Description of tests that were run to exercise the solutions (unit tests, system tests, etc)