### PR TITLE
forward additional args without extra quoting and add =

### DIFF
--- a/src/incubator/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
+++ b/src/incubator/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
@@ -65,8 +65,7 @@ spec:
         - /tmp/creds
 {{- end }}
         {{- range $key, $value := .Values.args }}
-        - --{{ $key | replace "_" "-"}}
-        - {{ $value | quote }}
+        - --{{ $key | replace "_" "-"}}={{ $value }}
         {{- end }}
 {{- if not .Values.secret_env }}
       volumes:


### PR DESCRIPTION
this fix enables the helm deployement to forward all additional arguments to the controller. It fixes bug as described in issue #27 