### PR TITLE
Fix #38: Add the possibility to configure how Pods are scheduled

### DIFF
--- a/src/incubator/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
+++ b/src/incubator/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
@@ -71,6 +71,14 @@ spec:
         - --{{ $key | replace "_" "-"}}
         - {{ $value | quote }}
         {{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}
 {{- if not .Values.secret_env }}
       volumes:
       - name: bigip-creds

--- a/src/incubator/f5-bigip-ctlr/values.yaml
+++ b/src/incubator/f5-bigip-ctlr/values.yaml
@@ -60,3 +60,15 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 version: devel-master
+
+# Labels for assigning pod(s) to specific node(s).
+nodeSelector: {}
+  # Example:
+  # node-role.kubernetes.io/master: ""
+
+# Tolerations to match node taints.
+tolerations: []
+  # Example:
+  # - effect: NoSchedule
+  #   key: node-role.kubernetes.io/master
+  


### PR DESCRIPTION
Fix: #38 

Problem: Today there's no way of configuring how Pods are scheduled

Solution:

Add configurable nodeSelector and tolerations to the Deployment template and values file.

I've added empty values as default to the values file, there's also commented examples on how this can be done. In the case of the examples they force scheduling of the controller Pod(s) onto the master nodes in the cluster.

If nodeSelector and tolerations are set in the values file they're rendered in the final manifest generated with helm.

Testing (optional if not described in Solution section): 