### PR TITLE
Added support for livenessProbe, ReadinessProbe, nodeSelectors, tolerations

### DIFF
--- a/src/stable/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
+++ b/src/stable/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
@@ -36,6 +36,14 @@ spec:
       containers:
       - name: {{ template "f5-bigip-ctlr.name" . }}
         image: "{{ .Values.image.user }}/{{ .Values.image.repo }}:{{ .Values.version }}"
+{{- if.Values.livenessProbe }}
+        livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 10 }}
+{{- end}}
+{{- if.Values.readinessProbe }}
+        readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 10 }}
+{{- end}}
         volumeMounts:
         - name: bigip-creds
           mountPath: "/tmp/creds"
@@ -49,6 +57,14 @@ spec:
         {{- range $key, $value := .Values.args }}
         - --{{ $key | replace "_" "-"}}={{ $value }}
         {{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6}}
+{{- end }}
       volumes:
       - name: bigip-creds
         secret:


### PR DESCRIPTION
Addressed this github issues:

[f5-bigip-ctlr] health check / probe missing

#34
[RFE] Add possibility to schedule the BIG-IP controller to k8s controller/master nodes

#38
Stories worked on:
CONTCNTR-2378 - [IPAM] Helm charts for CIS to include support for FIC
