### PR TITLE
image version is empty when using custom value

### DIFF
--- a/src/stable/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
+++ b/src/stable/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
@@ -64,7 +64,7 @@ spec:
         {{- end }}
       containers:
       - name: {{ template "f5-bigip-ctlr.name" . }}
-        image: "{{ .Values.image.user }}/{{ .Values.image.repo }}:{{ .Values.version }}"
+        image: "{{ .Values.image.user }}/{{ .Values.image.repo }}:{{ .Values.image.version }}"
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
When using custom image value, chart doesn't pick its name.
According to doc this section should be sufficient:

```yaml
image:
  # Use the tag to target a specific version of the Controller
  user: f5networks
  repo: k8s-bigip-ctlr
  pullPolicy: IfNotPresent
  version: someversion
```
When used this way, value for version is empty. You can workaround this by:

```yaml
image:
  # Use the tag to target a specific version of the Controller
  user: f5networks
  repo: k8s-bigip-ctlr
  pullPolicy: IfNotPresent
version: someversion
```
which is illogical.
This PR fixes deploy template to substitute from `Values.image.version` instead of `Values.version`
