### PR TITLE
Migrating manifests and API clients to use the rbac.authorization.k8s.io/v1 API version

### DIFF
--- a/src/stable/f5-bigip-ctlr/README.md
+++ b/src/stable/f5-bigip-ctlr/README.md
@@ -52,6 +52,7 @@ namespace | Optional | name of namespace CIS will use to create deployment and o
 image.user | Optional | CIS Controller image repository username | f5networks
 image.repo | Optional | CIS Controller image repository name | k8s-bigip-ctlr
 image.pullPolicy | Optional | CIS Controller image pull policy | Always
+image.pullSecrets | Optional | List of secrets of container registry to pull image | empty
 version | Optional | CIS Controller image tag | latest
 nodeSelector | Optional | dictionary of Node selector labels | empty
 tolerations | Optional | Array of labels | empty

--- a/src/stable/f5-bigip-ctlr/templates/f5-bigip-ctlr-clusterrole.yaml
+++ b/src/stable/f5-bigip-ctlr/templates/f5-bigip-ctlr-clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create -}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "f5-bigip-ctlr.fullname" . }}
   labels:

--- a/src/stable/f5-bigip-ctlr/templates/f5-bigip-ctlr-clusterrolebinding.yaml
+++ b/src/stable/f5-bigip-ctlr/templates/f5-bigip-ctlr-clusterrolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create -}}
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "f5-bigip-ctlr.fullname" . }}
   namespace: {{ template "f5-bigip-ctlr.namespace" . }}


### PR DESCRIPTION
Migrating manifests and API clients to use the rbac.authorization.k8s.io/v1 API version