### PR TITLE
update documentation references

### DIFF
--- a/src/stable/f5-bigip-ctlr/values.yaml
+++ b/src/stable/f5-bigip-ctlr/values.yaml
@@ -1,10 +1,10 @@
 # For additional information on installing the k8-bigip-ctlr please see:
-# Kubernetes: http://clouddocs.f5.com/containers/latest/kubernetes/kctlr-app-install.html
-# OpenShift: http://clouddocs.f5.com/containers/latest/openshift/kctlr-openshift-app-install.html#install-kctlr-openshift
+# Kubernetes: https://clouddocs.f5.com/containers/latest/userguide/kubernetes/
+# OpenShift: https://clouddocs.f5.com/containers/latest/userguide/openshift/
 #
 # access / permissions / RBAC
 # To create a secret using kubectl see
-# http://clouddocs.f5.com/containers/latest/kubernetes/kctlr-secrets.html#secret-bigip-login
+# https://clouddocs.f5.com/containers/latest/userguide/kubernetes/#installing-cis-manually
 bigip_login_secret: f5-bigip-ctlr-login
 rbac:
   create: true


### PR DESCRIPTION
a couple of the documentation references were out-dated and ended up landing on clouddocs.f5.com