### PR TITLE
Fix #63 Update to make "latest" default on deployment template 

### DIFF
--- a/src/stable/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
+++ b/src/stable/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
@@ -64,7 +64,11 @@ spec:
         {{- end }}
       containers:
       - name: {{ template "f5-bigip-ctlr.name" . }}
+        {{- if .Values.version }}
         image: "{{ .Values.image.user }}/{{ .Values.image.repo }}:{{ .Values.version }}"
+        {{- else }}
+        image: "{{ .Values.image.user }}/{{ .Values.image.repo}}"
+        {{- end }}
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Problem: Image pull would error on machines running CRI-O due to the colon being added after the image name regardless of whether the version variable was defined in the values.yaml.

Solution: Added logic to only have the colon when version is defined.

Testing: Ran helm chart on cluster running CRI-O and another running Containerd